### PR TITLE
API 호출시 Server/Client Cookie 접근 관련 이슈 해결

### DIFF
--- a/src/hooks/useSpotifyPlayer.ts
+++ b/src/hooks/useSpotifyPlayer.ts
@@ -22,7 +22,7 @@ export default function useSpotifyPlayer() {
       playerInstance = new (window as any).Spotify.Player({
         name: "Web Playback SDK",
         getOAuthToken: (cb: any) => {
-          cb(token?.replace(/\"/g, ""));
+          cb(JSON.stringify(token).replace(/\"/g, ""));
         },
         volume: 0.5,
       });

--- a/src/hooks/useSpotifyPlayer.ts
+++ b/src/hooks/useSpotifyPlayer.ts
@@ -1,8 +1,12 @@
-import { getCookieString } from "@/utils";
+import { getClientSideCookieValue } from "@/utils/cookies.client";
 import { useEffect } from "react";
 
 export default function useSpotifyPlayer() {
-  const token = getCookieString("access_token");
+  const getToken = async () => {
+    const accessToken = await getClientSideCookieValue("access_token");
+    return accessToken;
+  };
+  const token = getToken();
 
   useEffect(() => {
     if (!token) return;

--- a/src/utils/auth.ts
+++ b/src/utils/auth.ts
@@ -11,19 +11,33 @@ export const removeAccessToken = () => {
 export const saveTokenParams = (params: any) => {
   setCookie("access_token", params.access_token ?? "");
   setCookie("expires_in", params.expires_in ?? "");
-  // if (params?.refresh_token) {
-  //   setCookie("refresh_token", params?.refresh_token, {
-  //     path: "/",
-  //     httpOnly: true,
-  //     secure: true,
-  //     maxAge: 60 * 60 * 24 * 30,
-  //     sameSite: "lax",
-  //   });
-  // }
 };
 
 export const removeTokenParams = () => {
   deleteCookie("access_token");
   deleteCookie("expires_in");
   deleteCookie("refresh_token");
+};
+
+export const getSpotifyAuthUrl = () => {
+  const params = {
+    response_type: "token",
+    client_id: process.env.SPOTIFY_CLIENT_ID,
+    redirect_uri: process.env.SPOTIFY_REDIRECT_URI,
+    scope: [
+      "user-read-currently-playing",
+      "user-read-recently-played",
+      "user-read-playback-state",
+      "user-top-read",
+      "user-modify-playback-state",
+      "streaming",
+      "user-read-email",
+      "user-read-private",
+    ].join("%20"),
+    show_dialog: "true",
+  };
+
+  return `${process.env.SPOTIFY_AUTHORIZE_URL}?${new URLSearchParams(
+    params
+  ).toString()}`;
 };

--- a/src/utils/cookies.client.ts
+++ b/src/utils/cookies.client.ts
@@ -1,0 +1,19 @@
+"use client";
+
+import { getCookie, getCookies, TmpCookiesObj } from "cookies-next";
+
+export const getClientSideCookieValue = async (
+  name: string
+): Promise<string | undefined> => {
+  return await getCookie(name);
+};
+
+export const getClientSideCookies = async (): Promise<
+  | Partial<{
+      [key: string]: string;
+    }>
+  | Promise<TmpCookiesObj>
+  | undefined
+> => {
+  return await getCookies();
+};

--- a/src/utils/cookies.server.ts
+++ b/src/utils/cookies.server.ts
@@ -1,0 +1,20 @@
+"use server";
+
+import { getCookie, getCookies, TmpCookiesObj } from "cookies-next";
+import { cookies } from "next/headers";
+
+export const getServerSideCookieValue = async (
+  name: string
+): Promise<string | undefined> => {
+  return await getCookie(name, { cookies });
+};
+
+export const getServerSideCookies = async (): Promise<
+  | Partial<{
+      [key: string]: string;
+    }>
+  | Promise<TmpCookiesObj>
+  | undefined
+> => {
+  return await getCookies({ cookies });
+};


### PR DESCRIPTION
### 배경
- Service 클래스 내의 request 함수에서 next/headers 통해 cookie를 가져와서 cookie의 access_token 으로 인증하는 로직 작성

### 이슈
- 클라이언트 컴포넌트에서 Service 객체를 통해 API 요청시 next/headers 에 접근할 수 없다는 에러 발생

### 해결 방법
- cookie를 가져오는 로직을 cookie.server.ts, cookie.client.ts 유틸함수로 각각 분리
- client/server 분기하여 각각의 유틸함수로 쿠키 가져오도록 Service 클래스 request 로직 수정

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Added a new function to generate Spotify authorization URL.
	- Introduced client-side and server-side cookie utility functions for improved cookie management.

- **Refactor**
	- Enhanced token and authentication handling.
	- Updated cookie retrieval and management methods in the Service class.
	- Modified authentication token route to improve response and cookie handling.
	- Updated access token retrieval in the Spotify player hook to use asynchronous methods.

- **Chores**
	- Removed commented-out code related to token saving.

The release focuses on improving authentication and cookie management across the application, providing more flexible and robust methods for handling tokens and user sessions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->